### PR TITLE
[FEAT]경험치 증가, 레벨업 기능 구현

### DIFF
--- a/src/main/java/jungleEscape/member/controller/MemberController.java
+++ b/src/main/java/jungleEscape/member/controller/MemberController.java
@@ -1,0 +1,27 @@
+package jungleEscape.member.controller;
+
+import jungleEscape.common.dto.SuccessResponse;
+import jungleEscape.member.dto.ExpRequest;
+import jungleEscape.member.service.MemberService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    public MemberController(MemberService memberService){
+        this.memberService = memberService;
+    }
+
+    @PostMapping("v1/members/success")
+    public ResponseEntity<SuccessResponse<?>> updateScore(@RequestBody ExpRequest expRequest){
+        memberService.updateScore(expRequest.getQuest_exp());
+        return ResponseEntity.ok(SuccessResponse.success("경험치가 증가하였습니다."));
+    }
+}

--- a/src/main/java/jungleEscape/member/dto/ExpRequest.java
+++ b/src/main/java/jungleEscape/member/dto/ExpRequest.java
@@ -1,0 +1,9 @@
+package jungleEscape.member.dto;
+
+public class ExpRequest {
+    Integer quest_exp;
+
+    public Integer getQuest_exp(){
+        return quest_exp;
+    }
+}

--- a/src/main/java/jungleEscape/member/entity/Member.java
+++ b/src/main/java/jungleEscape/member/entity/Member.java
@@ -11,7 +11,7 @@ public class Member {
     Long id;
 
     @Column
-    Integer exp=70;
+    public Integer exp=70;
 
     @Column
     Integer level=1;
@@ -36,6 +36,14 @@ public class Member {
 
     public Integer getLevel(){
         return level;
+    }
+
+    public void setExp(Integer exp){
+        this.exp = exp;
+    }
+
+    public void setLevel(Integer level){
+        this.level = level;
     }
 }
 

--- a/src/main/java/jungleEscape/member/repository/ImageRepository.java
+++ b/src/main/java/jungleEscape/member/repository/ImageRepository.java
@@ -1,4 +1,7 @@
 package jungleEscape.member.repository;
 
+import org.springframework.stereotype.Repository;
+
+@Repository
 public interface ImageRepository {
 }

--- a/src/main/java/jungleEscape/member/repository/MemberRepository.java
+++ b/src/main/java/jungleEscape/member/repository/MemberRepository.java
@@ -1,4 +1,10 @@
 package jungleEscape.member.repository;
 
-public interface MemberRepository {
+import jungleEscape.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
 }

--- a/src/main/java/jungleEscape/member/service/MemberService.java
+++ b/src/main/java/jungleEscape/member/service/MemberService.java
@@ -1,0 +1,49 @@
+package jungleEscape.member.service;
+
+
+import jungleEscape.member.entity.Member;
+import jungleEscape.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public MemberService(MemberRepository memberRepository){
+        this.memberRepository = memberRepository;
+    }
+
+    public void updateScore(Integer quest_exp) {
+
+        Member member = memberRepository.findById(1L)
+                .orElseThrow(() -> new RuntimeException("Member not found"));
+
+        int addedExp = member.getExp() + quest_exp;
+        int memberLevel = member.getLevel();
+
+        while (true) {
+            int maxExp = getMaxExpForLevel(memberLevel);
+
+            if (addedExp >= maxExp) {
+                addedExp -= maxExp;
+                memberLevel++;
+            } else {
+                break;
+            }
+        }
+
+        member.setExp(addedExp);
+        member.setLevel(memberLevel);
+
+        memberRepository.save(member);
+    }
+
+    private int getMaxExpForLevel(int level) {
+        if (level == 1) {
+            return 100;
+        } else if (level == 2) {
+            return 150;
+        } else return 0;
+    }
+}


### PR DESCRIPTION
## ✨ Related Issue
- #1

## 📝 기능 구현 명세
1레벨일 때 레벨업 필요 경험치  : 100
2레벨일 때 레벨업 필요 경험치 : 150 

경험치 증가, 레벨업 구현하였습니다. 
![image](https://github.com/user-attachments/assets/f50d5fb4-b581-4e46-9922-62c1fc719720)


## 🐥 추가적인 언급 사항
